### PR TITLE
Added getCalStatus method

### DIFF
--- a/DFRobot_BNO055.cpp
+++ b/DFRobot_BNO055.cpp
@@ -83,6 +83,15 @@ DFRobot_BNO055::eStatus_t DFRobot_BNO055::begin()
 
 // get data functions ----------------------------------------------------------------
 
+// get calibration status registers
+DFRobot_BNO055::sRegCalibState_t DFRobot_BNO055::getCalStatus()
+{
+  sRegCalibState_t    sRegCal = {0};
+  setToPage(0);
+  readReg(regOffset0(sRegsPage0.CALIB_STATE), (uint8_t*) &sRegCal, sizeof(sRegCal));
+  return sRegCal;
+}
+
 // get register offset of raw data
 uint8_t getOffsetOfData(DFRobot_BNO055::eAxis_t eAxis)
 {

--- a/DFRobot_BNO055.h
+++ b/DFRobot_BNO055.h
@@ -614,6 +614,12 @@ public:
   eStatus_t   begin();
 
   /**
+   * @brief getCalStatus Get calibration status register
+   * @return Struct sRegCalibState_t, contains calibration status register values
+   */
+  sRegCalibState_t getCalStatus();
+  
+  /**
    * @brief getAxisAnalog Get axis analog data
    * @param eAxis One axis type from eAxis_t
    * @return Struct sAxisAnalog_t, contains axis analog data, members unit depend on eAxis:


### PR DESCRIPTION
Added a method to read calibration status registers. Structure `typedef struct sRegCalibState_t` is already defined and `CALIB_STATE` existed in register map. However, there was no method for the user to read these from library. This now exists as `getCalStatus()`.

Added to `DFRobot_BNO055.cpp`
```
// get calibration status registers
DFRobot_BNO055::sRegCalibState_t DFRobot_BNO055::getCalStatus()
{
  sRegCalibState_t    sRegCal = {0};
  setToPage(0);
  readReg(regOffset0(sRegsPage0.CALIB_STATE), (uint8_t*) &sRegCal, sizeof(sRegCal));
  return sRegCal;
}
```

Added to `DFRobot_BNO055.h`
```
/**
   * @brief getCalStatus Get calibration status register
   * @return Struct sRegCalibState_t, contains calibration status register values
   */
  sRegCalibState_t getCalStatus();
```

Example for use:
```
#include "DFRobot_BNO055.h"
#include "Wire.h"

typedef DFRobot_BNO055_IIC    BNO;    // ******** use abbreviations instead of full names ********

BNO   bno(&Wire, 0x28);    // input TwoWire interface and IIC address

// show last sensor operate status
void printLastOperateStatus(BNO::eStatus_t eStatus)
{
  switch(eStatus) {
  case BNO::eStatusOK:   Serial.println("everything ok"); break;
  case BNO::eStatusErr:  Serial.println("unknow error"); break;
  case BNO::eStatusErrDeviceNotDetect:   Serial.println("device not detected"); break;
  case BNO::eStatusErrDeviceReadyTimeOut:    Serial.println("device ready time out"); break;
  case BNO::eStatusErrDeviceStatus:    Serial.println("device internal status error"); break;
  default: Serial.println("unknow status"); break;
  }
}

void setup()
{
  Serial.begin(115200);
  bno.reset();
  while(bno.begin() != BNO::eStatusOK) {
    Serial.println("bno begin faild");
    printLastOperateStatus(bno.lastOperateStatus);
    delay(2000);
  }
  Serial.println("bno begin success");
}

void loop()
{
  BNO::sRegCalibState_t sRegCalibState;
  sRegCalibState = bno.getCalStatus();
  Serial.print("MAG Status = ");
  Serial.println(sRegCalibState.MAG);
  Serial.print("ACC Status = ");
  Serial.println(sRegCalibState.ACC);
  Serial.print("GYR Status = ");
  Serial.println(sRegCalibState.GYR);
  Serial.print("SYS Status = ");
  Serial.println(sRegCalibState.SYS);

  delay(1000);
}
```

Example output:
```
MAG Status = 3
ACC Status = 1
GYR Status = 0
SYS Status = 3
```