### PR TITLE
bugfix in setGyrIntEnable and setGyrIntDisable

### DIFF
--- a/DFRobot_BNO055.cpp
+++ b/DFRobot_BNO055.cpp
@@ -410,7 +410,7 @@ void DFRobot_BNO055::setAccHighGDuration(uint16_t dur)
   }
   uint8_t   temp = dur / 2;
   setToPage(1);
-  writeReg(regOffset1(sRegsPage1.ACC_HG_THRES), (uint8_t*) temp, sizeof(temp));
+  writeReg(regOffset1(sRegsPage1.ACC_HG_THRES), (uint8_t*) &temp, sizeof(temp));
 }
 
 void DFRobot_BNO055::setAccHighGThres(uint16_t thres)

--- a/DFRobot_BNO055.cpp
+++ b/DFRobot_BNO055.cpp
@@ -473,18 +473,18 @@ void DFRobot_BNO055::setGyrIntEnable(eGyrIntSet_t eInt)
 {
   uint8_t   temp;
   setToPage(1);
-  readReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) temp, sizeof(temp));
+  readReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) &temp, sizeof(temp));
   temp |= eInt;
-  writeReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) temp, sizeof(temp));
+  writeReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) &temp, sizeof(temp));
 }
 
 void DFRobot_BNO055::setGyrIntDisable(eGyrIntSet_t eInt)
 {
   uint8_t   temp;
   setToPage(1);
-  readReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) temp, sizeof(temp));
+  readReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) &temp, sizeof(temp));
   temp &= ~ eInt;
-  writeReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) temp, sizeof(temp));
+  writeReg(regOffset1(sRegsPage1.GYR_INT_SETTING), (uint8_t*) &temp, sizeof(temp));
 }
 
 void DFRobot_BNO055::setGyrHrSet(eSingleAxis_t eSingleAxis, uint16_t thres, uint16_t dur)

--- a/DFRobot_BNO055.cpp
+++ b/DFRobot_BNO055.cpp
@@ -514,6 +514,32 @@ void DFRobot_BNO055::setGyrAmThres(uint8_t thres)
   writeReg(regOffset1(sRegsPage1.GYR_AM_THRES), (uint8_t*) &thres, sizeof(thres));
 }
 
+void DFRobot_BNO055::setGyrIntAmDur(uint8_t dur)
+{
+  if ((dur > 4) || (dur < 1))
+  {
+    lastOperateStatus = eStatusErrParameter;
+    return;
+  }
+  sRegGyrAmSet_t sRegFleid = {0}, sRegVal = {0};
+  sRegFleid.AWAKE_DURATION = 0xff;
+  sRegVal.AWAKE_DURATION = dur - 1;
+  writeRegBitsHelper(1, sRegsPage1.GYR_AM_SET, sRegFleid, sRegVal);
+}
+
+void DFRobot_BNO055::setGyrIntAmSlope(uint8_t slope)
+{
+  if (slope > 3)
+  {
+    lastOperateStatus = eStatusErrParameter;
+    return;
+  }
+  sRegGyrAmSet_t sRegFleid = {0}, sRegVal = {0};
+  sRegFleid.SLOPE_SAMPLES = 0xff;
+  sRegVal.SLOPE_SAMPLES = slope;
+  writeRegBitsHelper(1, sRegsPage1.GYR_AM_SET, sRegFleid, sRegVal);
+}
+
 // protected functions ----------------------------------------------------------------
 
 uint8_t DFRobot_BNO055::getReg(uint8_t reg, uint8_t pageId)

--- a/DFRobot_BNO055.h
+++ b/DFRobot_BNO055.h
@@ -860,6 +860,19 @@ public:
    */
   void    setGyrAmThres(uint8_t thres);
 
+  /**
+   * @brief setGyrIntAmDur Set gyroscope any motion interrupt awake duration
+   * @param dur Duration to set, range from 1 to 4
+   *            1=8 samples, 2=16 samples, 3=32 samples, 4=64 samples
+   */
+  void setGyrIntAmDur(uint8_t dur);
+
+  /**
+   * @brief setGyrIntAmSlope Set gyroscope any motion interrupt slope samples
+   * @param slope Number of samples to evaluate (0-3): 0=4 samples, 1=8 samples, 2=16 samples, 3=32 samples
+   */
+  void setGyrIntAmSlope(uint8_t slope);
+
 protected:
   virtual void readReg(uint8_t reg, uint8_t *pBuf, uint8_t len) = 0;
   virtual void writeReg(uint8_t reg, uint8_t *pBuf, uint8_t len) = 0;


### PR DESCRIPTION
bugfix in setGyrIntEnable and setGyrIntDisable:

Both functions were incorrectly casting the value of temp as a pointer instead of passing the address of temp:

Wrong: (uint8_t *)temp
Correct: (uint8_t *)&temp

This caused the I2C read/write operations to try accessing random memory addresses (whatever value was in the uninitialized temp variable), which triggered a memory access violation and rebooted your ESP.

also added functions to set gyro any-motion duration and slope